### PR TITLE
Fix error thrown by iv_drag_begin when dragging multiple pages

### DIFF
--- a/pdfshuffler/pdfshuffler.py
+++ b/pdfshuffler/pdfshuffler.py
@@ -717,7 +717,7 @@ class PdfShuffler:
 
         if len(iconview.get_selected_items()) > 1:
             iconview.stop_emission('drag_begin')
-            context.set_icon_stock(Gtk.STOCK_DND_MULTIPLE, 0, 0)
+            Gtk.drag_set_icon_name(context, "gtk-dnd-multiple", 0, 0)
 
     def iv_dnd_get_data(self, iconview, context,
                         selection_data, target_id, etime):


### PR DESCRIPTION
Fix for the following error when dragging multiple pages:
```
Traceback (most recent call last):
  File "[...]/pdfshuffler/pdfshuffler.py", line 720, in iv_drag_begin
    context.set_icon_stock(Gtk.STOCK_DND_MULTIPLE, 0, 0)
AttributeError: 'X11DragContext' object has no attribute 'set_icon_stock'
```