### PR TITLE
Fix bytes conversion

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -927,7 +927,6 @@ class PdfShuffler:
 
         data = selection_data.get_data()
         if target_id == self.MODEL_ROW_EXTERN:
-            self.model
             if data:
                 data = data.split('\n;\n')
             while data:

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -925,8 +925,8 @@ class PdfShuffler:
                              selection_data, target_id, etime):
         """Handles received data by drag and drop in scrolledwindow"""
 
-        data = selection_data.get_data()
         if target_id == self.MODEL_ROW_EXTERN:
+            data = selection_data.get_data().decode()
             if data:
                 data = data.split('\n;\n')
             while data:
@@ -938,9 +938,7 @@ class PdfShuffler:
                     if context.get_actions() & Gdk.DragAction.MOVE:
                         context.finish(True, True, etime)
         elif target_id == self.TEXT_URI_LIST:
-            uri = data.strip()
-            uri_splitted = uri.split() # we may have more than one file dropped
-            for uri in uri_splitted:
+            for uri in selection_data.get_uris():
                 filename = self.get_file_path_from_dnd_dropped_uri(uri)
                 try:
                     if os.path.isfile(filename): # is it a file?
@@ -988,11 +986,6 @@ class PdfShuffler:
 
     def get_file_path_from_dnd_dropped_uri(self, uri):
         """Extracts the path from an uri"""
-        try:
-            # Python 3
-            uri = uri.decode()
-        except AttributeError:
-            pass
         path = url2pathname(uri) # escape special chars
         path = path.strip('\r\n\x00')   # remove \r\n and NULL
 

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -561,7 +561,6 @@ class PdfShuffler:
             try:
                 self.save(False, all_files.pop())
             except Exception as e:
-                chooser.destroy()
                 self.error_message_dialog(e)
                 return
 


### PR DESCRIPTION
Remove `chooser.destroy()` where chooser is not defined
Remove pointless statement `self.model`

Fix the following error when dropping a page into the scrollview:
```
Traceback (most recent call last):
  File "[...]/pdfshuffler/pdfshuffler.py", line 930, in sw_dnd_received_data
    data = data.split('\n;\n')
TypeError: a bytes-like object is required, not 'str'
```

Use SelectionData::get_uris() and decode() where appropriate.
Remove now unneeded decode() call in `get_file_path_from_dnd_dropped_uri`.

I did various tests with Python 2 and Python 3 on Linux and found no errors.