### PR TITLE
Improve handling of SIGINT

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -79,6 +79,7 @@ from gi.repository import Gdk
 from gi.repository import GObject      # for using custom signals
 from gi.repository import Pango        # for adjusting the text alignment in CellRendererText
 from gi.repository import Gio          # for inquiring mime types information
+from gi.repository import GLib
 gi.require_version('Poppler', '0.18')
 from gi.repository import Poppler      #for the rendering of pdf pages
 import cairo
@@ -92,6 +93,7 @@ from .iconview import CellRendererImage
 GObject.type_register(CellRendererImage)
 
 import time
+import signal
 
 class PdfShuffler:
     prefs = {
@@ -144,6 +146,7 @@ class PdfShuffler:
         self.window.set_default_size(self.prefs['window width'],
                                      self.prefs['window height'])
         self.window.connect('delete_event', self.close_application)
+        GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGINT, self.close_application)
 
         # Create a scrolled window to hold the thumbnails-container
         self.sw = self.uiXML.get_object('scrolledwindow')
@@ -428,7 +431,7 @@ class PdfShuffler:
         elif event.keyval == 65379:  # Key Insert
             self.on_action_add_doc_activate('')
 
-    def close_application(self, widget, event=None, data=None):
+    def close_application(self, widget=None, event=None, data=None):
         """Termination"""
 
         if self.rendering_thread:


### PR DESCRIPTION
Up to now you couldn't stop pdfarranger by pressing Ctrl+C in the terminal or your IDEs Stop button, this PR fixes this for better user experience and faster development.

Tested with Python 2 and 3 on Linux.

`GLib.unix_signal_add` suggests that it might not work on Windows (Let's hope it's just a silent noop in this case). Furthermore I don't know if such functionality is needed or wanted on Windows, what do you think @carlos22 ?