### PR TITLE
Fix reverse order function

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1146,7 +1146,7 @@ class PdfShuffler:
 
         self.set_unsaved(True)
         indices.reverse()
-        new_order = range(first) + indices + range(last + 1, len(model))
+        new_order = list(range(first)) + indices + list(range(last + 1, len(model)))
         model.reorder(new_order)
 
     def about_dialog(self, widget, data=None):


### PR DESCRIPTION
Fixes error when using the reverse order function with python3: 
```
Traceback (most recent call last):
  File "/home/da/git/pdfarranger/pdfarranger/pdfarranger.py", line 1178, in reverse_order
    new_order = range(first) + indices + range(last + 1, len(model))
TypeError: unsupported operand type(s) for +: 'range' and 'list'

```