### PR TITLE
Needs input: Disable strict mode for PdfFileReader

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -636,7 +636,7 @@ class PdfArranger:
         pdf_output = PdfFileWriter()
         pdf_input = []
         for pdfdoc in self.pdfqueue:
-            pdfdoc_inp = PdfFileReader(open(pdfdoc.copyname, 'rb'))
+            pdfdoc_inp = PdfFileReader(open(pdfdoc.copyname, 'rb'), strict = False)
             if pdfdoc_inp.getIsEncrypted():
                 try: # Workaround for lp:#355479
                     stat = pdfdoc_inp.decrypt('')


### PR DESCRIPTION
With strict = False exporting certain pdf files (e.g. https://github.com/jeromerobert/pdfarranger/issues/54) works. 
Warnings are printed to stdout so they can be easily missed and are not visible at all when the application is not started from a command line.