### PR TITLE
change default version to latest tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ sudo dnf install poppler-glib python3-distutils-extra python3-pip python3-gobjec
 Then:
 
 ```
-pip3 install --user -r https://raw.githubusercontent.com/jeromerobert/pdfarranger/master/requirements.txt
+pip3 install --user -r https://raw.githubusercontent.com/jeromerobert/pdfarranger/1.1.1/requirements.txt
 ```
 
 # For developers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-https://github.com/jeromerobert/pdfarranger/zipball/master
+https://github.com/jeromerobert/pdfarranger/archive/1.1.1.zip
 PyPDF2


### PR DESCRIPTION
I think it makes sense to use the latest tag instead of the master branch. For me personally the version from master didn't work, but the 1.1.1 did.

I have tested it with the new links and it works.