### PR TITLE
Only show dialog if there were errors or warnings.

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -181,7 +181,8 @@ def warn_dialog(func):
         warnings.showwarning=ShowWarning()
         try:
             func(*args, **kwargs)
-            self.error_message_dialog(warnings.showwarning.buffer, Gtk.MessageType.WARNING)
+            if len(warnings.showwarning.buffer) > 0:
+                self.error_message_dialog(warnings.showwarning.buffer, Gtk.MessageType.WARNING)
         finally:
             warnings.showwarning=backup_showwarning
     return wrapper


### PR DESCRIPTION
Commit 46f036e5c5a9497bd469250cd9c0ea47c581fd80 introduced a change to accumulate warnings and errors and display them in a dialog. When there are no errors (warnings.showwarning.buffer=""), an empty dialog is displayed (on every save). This change only displays the dialog if warnings.showwarning.buffer has text.