### PR TITLE
Fix metainfo location

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ data_files = [
     ('share/applications', ['data/pdfarranger.desktop']),
     ('share/pdfarranger', ['data/pdfarranger.ui']),
     ('share/man/man1', ['doc/pdfarranger.1']),
-    ('share/appdata', ['data/pdfarranger.appdata.xml']),
+    ('share/metainfo', ['data/pdfarranger.appdata.xml']),
 ]
 
 setup(


### PR DESCRIPTION
According to [the freedesktop specification](https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html) appdata is legacy only and should not be used by new applications.