### PR TITLE
Remove shebang in __main__.py

### DIFF
--- a/pdfarranger/__main__.py
+++ b/pdfarranger/__main__.py
@@ -1,4 +1,3 @@
-#! /usr/bin/env python3
 import sys
 from pdfarranger import pdfarranger
 pdfarranger.PdfArranger().run(sys.argv)


### PR DESCRIPTION
Rpmlint complains about this. Since the executable bit is not set on this file, I think the shebang isn't needed either.