### PR TITLE
Add export selection menu item to file menu and add shortcut.

### DIFF
--- a/data/pdfarranger.ui
+++ b/data/pdfarranger.ui
@@ -80,6 +80,15 @@ Author: Konstantinos Poulios
                       </object>
                     </child>
                     <child>
+                      <object class="GtkMenuItem">
+                        <property name="label" translatable="yes">_Export selection...</property>
+                        <property name="use_underline">True</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="action_name">win.export-selection</property>
+                      </object>
+                    </child>
+                    <child>
                       <object class="GtkSeparatorMenuItem" id="separatormenuitem_file">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -253,6 +253,7 @@ class PdfArranger(Gtk.Application):
             ('rotate(-90)', '<Ctrl>Left'),
             ('save', '<Ctrl>s'),
             ('save-as', '<Ctrl><Shift>s'),
+            ('export-selection', '<Ctrl>e'),
             ('quit', '<Ctrl>q'),
             ('import', 'Insert'),
             ('zoom(5)', 'plus'),
@@ -905,7 +906,8 @@ class PdfArranger(Gtk.Application):
         selection = self.iconview.get_selected_items()
         ne = len(selection) > 0
         for a, e in [("reverse-order", self.reverse_order_available(selection)),
-                     ("delete", ne), ("crop", ne), ("rotate", ne)]:
+                     ("delete", ne), ("crop", ne), ("rotate", ne),
+                     ("export-selection", ne)]:
             self.window.lookup_action(a).set_enabled(e)
 
     def sw_dnd_received_data(self, scrolledwindow, context, x, y,


### PR DESCRIPTION
I think Ctrl+e is the obvious choice for a shortcut here.
The file menu seems to be more appropriate than the edit menu
since people want to save something.
I also added the export to the list of functions that are
disabled when nothing is selected.

Inspired by #95