### PR TITLE
Fix 'SyntaxWarning: "is not" with a literal. Did you mean "!="?'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+venv/

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -1004,7 +1004,7 @@ class PdfArranger(Gtk.Application):
             new_angle = new_angle % 360
             model.set_value(treeiter, 6, new_angle)
             self.update_geometry(treeiter)
-        return rotate_times is not 0 and len(selection) > 0
+        return rotate_times != 0 and len(selection) > 0
 
     def crop_page_dialog(self, action, parameter, unknown):
         """Opens a dialog box to define margins for page cropping"""


### PR DESCRIPTION
This warning is new in Python 3.8