### PR TITLE
Prevent Gtk-errors when closing with everything selected

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -546,6 +546,9 @@ class PdfArranger(Gtk.Application):
     def close_application(self, widget=None, event=None, data=None):
         """Termination"""
 
+        # Prevent gtk errors when closing with everything selected
+        self.iconview.unselect_all()
+
         if self.rendering_thread:
             self.rendering_thread.quit = True
             self.rendering_thread.join()


### PR DESCRIPTION
When you select all, e.g. by pressing Ctrl+A and close pdfarranger afterwards
the the following messages are printed for each page.

(pdfarranger:16430): Gtk-CRITICAL **: 12:55:35.115: gtk_cell_area_apply_attributes: assertion 'GTK_IS_CELL_AREA (area)' failed

(pdfarranger:16430): Gtk-CRITICAL **: 12:55:35.115: gtk_cell_area_foreach: assertion 'GTK_IS_CELL_AREA (area)' failed

Remove the selection prior to closing to prevent that.