### PR TITLE
Add filter by "application/pdf" to file choosers

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -620,6 +620,7 @@ class PdfArranger(Gtk.Application):
         filter_pdf = Gtk.FileFilter()
         filter_pdf.set_name(_('PDF files'))
         filter_pdf.add_pattern('*.pdf')
+        filter_pdf.add_mime_type('application/pdf')
         chooser.add_filter(filter_pdf)
 
         filter_all = Gtk.FileFilter()
@@ -701,6 +702,7 @@ class PdfArranger(Gtk.Application):
         filter_pdf = Gtk.FileFilter()
         filter_pdf.set_name(_('PDF files'))
         filter_pdf.add_pattern('*.pdf')
+        filter_pdf.add_mime_type('application/pdf')
         chooser.add_filter(filter_pdf)
         chooser.set_filter(filter_pdf)
 


### PR DESCRIPTION
Restores previously well-working behavior on non-window$, while still keep working on window$ because filters are OR-ed.