### PR TITLE
Fix German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -35,7 +35,6 @@ msgstr "Hersteller"
 
 #: pdfarranger/metadata.py:33
 msgid "Creator tool"
-# not sure what that is and how to translate it
 msgstr "Erstellungswerkzeug"
 
 #: pdfarranger/metadata.py:91 data/pdfarranger.ui.h:10


### PR DESCRIPTION
Build was failing because of `msgfmt` not being happy with the comment between `msgid` and `msgstr`.

```
msgfmt po/de.po -o build/mo/de/LC_MESSAGES/pdfarranger.mo
po/de.po:37: missing 'msgstr' section
po/de.po:39:7: syntax error
```

btw @dreua: "CreatorTool" specifies the tool the PDF file was generated with, so "Erstellungswerkzeug" should be fine :)