### PR TITLE
 Always save edited values of metadata 

### DIFF
--- a/pdfarranger/metadata.py
+++ b/pdfarranger/metadata.py
@@ -80,7 +80,7 @@ def _metatostr(value, name):
 
 
 def _strtometa(value, name):
-    if len(value) == 0:
+    if value is None or len(value) == 0:
         return None
     try:
         r = json.loads(value) if name == _CREATOR else value


### PR DESCRIPTION
I wish PyGtk would have a better way to do this, but I'm quite sure that is the best we con do. It is not possible to cancel a single edit by pressing escape but since you still have the cancel button to cancel the whole edit I think that is no big deal. It definitely feels better for me if "Apply" is not reverting your current edit any more.
Looking forward to the 1.4.1 release 

Fixes: #130 