### PR TITLE
Run Actions on pull request

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,5 +1,5 @@
 name: pdfarranger
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I don't think that there are any credentials or anything else in the build process or the build container that could be exploited by malicious pull requests therefore this will be only beneficial to catch errors even earlier.