### PR TITLE
Update german translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -170,31 +170,31 @@ msgstr "Nach rechts drehen"
 
 #: data/menu.ui.h:1
 msgid "_Import"
-msgstr "Importieren"
+msgstr "_Importieren"
 
 #: data/menu.ui.h:2
 msgid "_Save"
-msgstr "Speichern"
+msgstr "_Speichern"
 
 #: data/menu.ui.h:3
 msgid "Save _As..."
-msgstr "Speichern unter ..."
+msgstr "Speichern _unter ..."
 
 #: data/menu.ui.h:4
 msgid "E_xport Selection..."
-msgstr "Markierte Seiten _exportieren ..."
+msgstr "Markierte Seiten e_xportieren ..."
 
 #: data/menu.ui.h:5
 msgid "_Undo"
-msgstr "Rückgängig"
+msgstr "_Rückgängig"
 
 #: data/menu.ui.h:6
 msgid "_Redo"
-msgstr "Wiederholen"
+msgstr "_Wiederholen"
 
 #: data/menu.ui.h:7
 msgid "_Edit"
-msgstr "Bearbeiten"
+msgstr "_Bearbeiten"
 
 #: data/menu.ui.h:8
 msgid "Rotate _Left"
@@ -206,75 +206,75 @@ msgstr "Nach _rechts drehen"
 
 #: data/menu.ui.h:10
 msgid "Cro_p"
-msgstr "Zuschneiden"
+msgstr "_Zuschneiden"
 
 #: data/menu.ui.h:11
 msgid "_Delete"
-msgstr "Entfernen"
+msgstr "_Entfernen"
 
 #: data/menu.ui.h:12
 msgid "Dupl_icate"
-msgstr "Duplizieren"
+msgstr "_Duplizieren"
 
 #: data/menu.ui.h:13
 msgid "Re_verse Order"
-msgstr "Reihenfolge _umkehren"
+msgstr "Rei_henfolge umkehren"
 
 #: data/menu.ui.h:14
 msgid "_Split pages"
-msgstr "Seiten teilen"
+msgstr "Seiten _teilen"
 
 #: data/menu.ui.h:15
 msgid "Cu_t"
-msgstr "Ausschneiden"
+msgstr "_Ausschneiden"
 
 #: data/menu.ui.h:16
 msgid "_Copy"
-msgstr "Kopieren"
+msgstr "_Kopieren"
 
 #: data/menu.ui.h:17
 msgid "Paste _After"
-msgstr "Einfügen nach Auswahl"
+msgstr "Einfügen _nach Auswahl"
 
 #: data/menu.ui.h:18
 msgid "Paste _Before"
-msgstr "Einfügen vor Auswahl"
+msgstr "Einfügen _vor Auswahl"
 
 #: data/menu.ui.h:19
 msgid "Paste Interleave _Odd"
-msgstr "Verzahnt einfügen ungerade"
+msgstr "Verzahnt einfügen _ungerade"
 
 #: data/menu.ui.h:20
 msgid "Paste Interleave _Even"
-msgstr "Verzahnt einfügen gerade"
+msgstr "Verzahnt einfügen _gerade"
 
 #: data/menu.ui.h:21
 msgid "Zoom _In"
-msgstr "Vergrössern"
+msgstr "Ver_grössern"
 
 #: data/menu.ui.h:22
 msgid "Zoom _Out"
-msgstr "Verkleinern"
+msgstr "Ver_kleinern"
 
 #: data/menu.ui.h:23
 msgid "Edit _Properties"
-msgstr "Eigenschaften ändern"
+msgstr "Eige_nschaften ändern"
 
 #: data/menu.ui.h:24
 msgid "_About"
-msgstr "Info zu PDF Arranger"
+msgstr "Info zu _PDF Arranger"
 
 #: data/menu.ui.h:25
 msgid "_Quit"
-msgstr "Beenden"
+msgstr "Been_den"
 
 #: data/menu.ui.h:26
 msgid "Past_e Special"
-msgstr "Einfügen"
+msgstr "Ein_fügen"
 
 #: data/menu.ui.h:27
 msgid "_Split Pages"
-msgstr "Seiten teilen"
+msgstr "Seiten _teilen"
 
 #~ msgid "_File"
 #~ msgstr "_Datei"

--- a/po/de.po
+++ b/po/de.po
@@ -5,6 +5,7 @@
 # See file COPYING or go to <http://www.gnu.org/licenses/> for full license details.
 # Translators:
 # Konstantinos Poulios, 2008-2017
+# David Auer, 2020
 msgid ""
 msgstr ""
 "Project-Id-Version: PDF-Shuffler 0.7\n"
@@ -140,7 +141,6 @@ msgid "Save"
 msgstr "Speichern"
 
 #: data/pdfarranger.ui.h:3
-#, fuzzy
 msgid "Save As"
 msgstr "Speichern unter"
 
@@ -153,42 +153,34 @@ msgid "Main Menu"
 msgstr "Hauptmenü"
 
 #: data/pdfarranger.ui.h:6
-#, fuzzy
 msgid "Zoom In"
 msgstr "Vergrössern"
 
 #: data/pdfarranger.ui.h:7
-#, fuzzy
 msgid "Zoom Out"
 msgstr "Verkleinern"
 
 #: data/pdfarranger.ui.h:8
-#, fuzzy
 msgid "Rotate Left"
-msgstr "Nach _links drehen"
+msgstr "Nach links drehen"
 
 #: data/pdfarranger.ui.h:9
-#, fuzzy
 msgid "Rotate Right"
-msgstr "Nach _rechts drehen"
+msgstr "Nach rechts drehen"
 
 #: data/menu.ui.h:1
-#, fuzzy
 msgid "_Import"
 msgstr "Importieren"
 
 #: data/menu.ui.h:2
-#, fuzzy
 msgid "_Save"
 msgstr "Speichern"
 
 #: data/menu.ui.h:3
-#, fuzzy
 msgid "Save _As..."
 msgstr "Speichern unter ..."
 
 #: data/menu.ui.h:4
-#, fuzzy
 msgid "E_xport Selection..."
 msgstr "Markierte Seiten _exportieren ..."
 
@@ -221,7 +213,6 @@ msgid "_Delete"
 msgstr "Entfernen"
 
 #: data/menu.ui.h:12
-#, fuzzy
 msgid "Dupl_icate"
 msgstr "Duplizieren"
 
@@ -230,7 +221,6 @@ msgid "Re_verse Order"
 msgstr "Reihenfolge _umkehren"
 
 #: data/menu.ui.h:14
-#, fuzzy
 msgid "_Split pages"
 msgstr "Seiten teilen"
 
@@ -259,17 +249,14 @@ msgid "Paste Interleave _Even"
 msgstr "Verzahnt einfügen gerade"
 
 #: data/menu.ui.h:21
-#, fuzzy
 msgid "Zoom _In"
 msgstr "Vergrössern"
 
 #: data/menu.ui.h:22
-#, fuzzy
 msgid "Zoom _Out"
 msgstr "Verkleinern"
 
 #: data/menu.ui.h:23
-#, fuzzy
 msgid "Edit _Properties"
 msgstr "Eigenschaften ändern"
 
@@ -286,7 +273,6 @@ msgid "Past_e Special"
 msgstr "Einfügen"
 
 #: data/menu.ui.h:27
-#, fuzzy
 msgid "_Split Pages"
 msgstr "Seiten teilen"
 
@@ -314,6 +300,5 @@ msgstr "Seiten teilen"
 #~ msgid "Delete"
 #~ msgstr "Löschen"
 
-#, fuzzy
 #~ msgid "C_rop"
 #~ msgstr "_Zuschneiden..."

--- a/po/de.po
+++ b/po/de.po
@@ -11,9 +11,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-04-11 10:54+0200\n"
 "PO-Revision-Date: 2019-07-18 20:51+0200\n"
-"Last-Translator: O. Giesmann <nutzer3105@gmail.com>\n"
-"Language-Team: German (http://www.transifex.com/logari81/pdfshuffler/"
-"language/de/)\n"
+"Last-Translator: David Auer <dreua@posteo.de>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -144,15 +142,15 @@ msgstr "Speichern"
 #: data/pdfarranger.ui.h:3
 #, fuzzy
 msgid "Save As"
-msgstr "Speichern als"
+msgstr "Speichern unter"
 
 #: data/pdfarranger.ui.h:4
 msgid "Number of Pages"
-msgstr ""
+msgstr "Anzahl Seiten"
 
 #: data/pdfarranger.ui.h:5
 msgid "Main Menu"
-msgstr ""
+msgstr "Hauptmenü"
 
 #: data/pdfarranger.ui.h:6
 #, fuzzy
@@ -187,7 +185,7 @@ msgstr "Speichern"
 #: data/menu.ui.h:3
 #, fuzzy
 msgid "Save _As..."
-msgstr "Speichern als"
+msgstr "Speichern unter ..."
 
 #: data/menu.ui.h:4
 #, fuzzy
@@ -196,11 +194,11 @@ msgstr "Markierte Seiten _exportieren ..."
 
 #: data/menu.ui.h:5
 msgid "_Undo"
-msgstr ""
+msgstr "Rückgängig"
 
 #: data/menu.ui.h:6
 msgid "_Redo"
-msgstr ""
+msgstr "Wiederholen"
 
 #: data/menu.ui.h:7
 msgid "_Edit"
@@ -216,7 +214,7 @@ msgstr "Nach _rechts drehen"
 
 #: data/menu.ui.h:10
 msgid "Cro_p"
-msgstr ""
+msgstr "Zuschneiden"
 
 #: data/menu.ui.h:11
 msgid "_Delete"
@@ -238,27 +236,27 @@ msgstr "Seiten teilen"
 
 #: data/menu.ui.h:15
 msgid "Cu_t"
-msgstr ""
+msgstr "Ausschneiden"
 
 #: data/menu.ui.h:16
 msgid "_Copy"
-msgstr ""
+msgstr "Kopieren"
 
 #: data/menu.ui.h:17
 msgid "Paste _After"
-msgstr ""
+msgstr "Einfügen nach Auswahl"
 
 #: data/menu.ui.h:18
 msgid "Paste _Before"
-msgstr ""
+msgstr "Einfügen vor Auswahl"
 
 #: data/menu.ui.h:19
 msgid "Paste Interleave _Odd"
-msgstr ""
+msgstr "Verzahnt einfügen ungerade"
 
 #: data/menu.ui.h:20
 msgid "Paste Interleave _Even"
-msgstr ""
+msgstr "Verzahnt einfügen gerade"
 
 #: data/menu.ui.h:21
 #, fuzzy
@@ -277,15 +275,15 @@ msgstr "Eigenschaften ändern"
 
 #: data/menu.ui.h:24
 msgid "_About"
-msgstr ""
+msgstr "Info zu PDF Arranger"
 
 #: data/menu.ui.h:25
 msgid "_Quit"
-msgstr ""
+msgstr "Beenden"
 
 #: data/menu.ui.h:26
 msgid "Past_e Special"
-msgstr ""
+msgstr "Einfügen"
 
 #: data/menu.ui.h:27
 #, fuzzy


### PR DESCRIPTION
I translated all the strings but many strings remain untranslated in the app anyway:

Tooltips

- Save as
- Rotate left/right
- Zoom in/out

Main Menu

- Import
- Save
- Save As
- Export selection
- Zoom in/out
- Edit properties

Edit Submenu and Context Menu

- Duplicate
- Split pages

### Todo

- [x]  Fix untranslated strings
- [x]  Access keys (underscores)
