### PR TITLE
Set outline css_data only for iconview

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -484,7 +484,7 @@ class PdfArranger(Gtk.Application):
         # Set outline properties for iconview items i.e. cursor look
         style_provider = Gtk.CssProvider()
         css_data = """
-        * {
+        iconview {
             outline-color: alpha(currentColor, 0.8);
             outline-style: dashed;
             outline-offset: -2px;


### PR DESCRIPTION
Sometimes when selecting import the thick dotted line appear:
![Dotted line](https://user-images.githubusercontent.com/60842129/79248527-9f342900-7e84-11ea-8c84-2d881fca1ebc.png)

..and when selecting edit properties this appear:
![Dotted line 2](https://user-images.githubusercontent.com/60842129/79248568-aa875480-7e84-11ea-9e60-6bbb54302799.png)

I saw this css sideeffect now when i tested the released 1.5.0
