### PR TITLE
Remove obsolete appdata id

### DIFF
--- a/data/com.github.jeromerobert.pdfarranger.metainfo.xml
+++ b/data/com.github.jeromerobert.pdfarranger.metainfo.xml
@@ -7,7 +7,6 @@ See file COPYING or go to <http://www.gnu.org/licenses/> for full license detail
 -->
 <component type="desktop-application">
   <id>com.github.jeromerobert.pdfarranger</id>
-  <id type="desktop">pdfarranger.desktop</id>
   <name>PDF Arranger</name>
   <summary>PDF file merging, rearranging, and splitting</summary>
   <launchable type="desktop-id">com.github.jeromerobert.pdfarranger.desktop</launchable>


### PR DESCRIPTION
Apparently flatpak builder is confused by two id tags:
https://flathub.org/builds/#/builders/12/builds/2165

And tbh I should have removed that line anyway.