### PR TITLE
Fix paste exception type and use private clipboard in linux

### DIFF
--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -831,7 +831,7 @@ class PdfArranger(Gtk.Application):
         while data:
             try:  # Clipboard can contain not expected data
                 self.data_to_pageadder(data, pageadder)
-            except:
+            except (ValueError, FileNotFoundError):
                 return False
         return pageadder.commit(select_added, add_to_undomanager=True)
 
@@ -848,7 +848,7 @@ class PdfArranger(Gtk.Application):
         while data:
             try:  # Clipboard can contain not expected data
                 self.data_to_pageadder(data, pageadder)
-            except:
+            except (ValueError, FileNotFoundError):
                 return
 
             pageadder.move(ref_to, before)

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -272,7 +272,10 @@ class PdfArranger(Gtk.Application):
         self.export_file = None
 
         # Clipboard for cut copy paste
-        self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        if os.name == 'nt':
+            self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        else:
+            self.clipboard = Gtk.Clipboard.get(Gdk.Atom.intern('_SELECTION_PDFARRANGER', False))
 
     def do_open(self, files, _n, _hints):
         """ https://lazka.github.io/pgi-docs/Gio-2.0/classes/Application.html#Gio.Application.do_open """


### PR DESCRIPTION
The clipboard data is only useful to pdfarranger, so I think it is best if it is not visible to other applications. We can also cause many errors by pasting to a text editor and manipulate the data, and paste that data back to pdfarranger. (#178 can also happen this way)

So this line:

self.clipboard = Gtk.Clipboard.get(Gdk.Atom.intern('_SELECTION_PDFARRANGER', False))

gives a "private" clipboard that can not be seen by other applications.
But unfortunately is does not work in windows. It doesn't throw any exceptions or anything, the clipboard just seems to be empty. So that's why windows does not use the same clipboard.

Could the reason be that some library or something is missing in the windows installation? Now when I have tested this in windows I have just replaced the pdfarranger.pyc with pdfarranger.py.