### PR TITLE
Add Keywords to .desktop

### DIFF
--- a/data/com.github.jeromerobert.pdfarranger.desktop
+++ b/data/com.github.jeromerobert.pdfarranger.desktop
@@ -12,3 +12,4 @@ MimeType=application/pdf;
 Categories=Office;
 Terminal=false
 StartupNotify=false
+Keywords=pdfarranger;pdfshuffler;PDF Shuffler;


### PR DESCRIPTION
It is [quite common](https://gitlab.gnome.org/GNOME/gnome-control-center/-/merge_requests/742/diffs) for desktop files to contain keywords in order to make it easier for users to find their apps. In a non-flatpak installation, `pdfarranger` is already included as keyword becaus it is in the Exec tag, but when installed as flatpak searching for `pdfa` or more does not yield any results (testing with Gnome). (PDF Arranger with a space or a hyphen is always found.)

I think it is reasonable to add pdfshuffler as keyword but I'm open for opinions on that.