### PR TITLE
Add paste pdf files feature & paste data error handling in Windows

### DIFF
--- a/pdfarranger/exporter.py
+++ b/pdfarranger/exporter.py
@@ -83,3 +83,13 @@ def export(input_files, pages, file_out, mdata):
         for k, v in mdata.items():
             outmeta[k] = v
     pdf_output.save(file_out)
+
+def num_pages(filepath):
+    """Get number of pages for filepath."""
+    try:
+        pdf = pikepdf.Pdf.open(filepath)
+    except pikepdf._qpdf.PdfError:
+        return None
+    npages = len(pdf.pages)
+    pdf.close()
+    return npages


### PR DESCRIPTION
Had to try to implement the feature mentioned in #182

Second commit should make it impossible to "manipulate" clipboard data with illegal data and cause errors in Pdfarranger in Windows. (copy pages in Pdfarranger -> paste to text editor -> change for example angle values to 45 degrees -> paste that data back to pdfarranger)

Tested with Dolphin, Nautilus and Thunar in Linux and File Explorer in Windows.

In Windows File Explorer a filepath can be copied with shift + right-click -> copy as path. Other methods to do it can be found here:

https://superuser.com/questions/1126793/create-copy-path-keyboard-shortcut-windows-10

Maybe not the most important feature to have, but quite useful anyway as it makes it possible to add files directly at desired location, with all four paste modes. (also multiple files can be copied at once) You may decide if it is worth to include it.