### PR TITLE
Add option to crop white borders

### DIFF
--- a/data/menu.ui
+++ b/data/menu.ui
@@ -69,6 +69,10 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
           <attribute name="action">win.crop</attribute>
         </item>
         <item>
+          <attribute name="label" translatable="yes">Crop White Borders</attribute>
+          <attribute name="action">win.crop-white-borders</attribute>
+        </item>
+        <item>
           <attribute name="label" translatable="yes">_Delete</attribute>
           <attribute name="action">win.delete</attribute>
         </item>
@@ -199,6 +203,10 @@ along with PDF-Arranger.  If not, see <http://www.gnu.org/licenses/>.
       <item>
         <attribute name="label" translatable="yes">Cro_p</attribute>
         <attribute name="action">win.crop</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Crop White Borders</attribute>
+        <attribute name="action">win.crop-white-borders</attribute>
       </item>
       <item>
         <attribute name="label" translatable="yes">Dupl_icate</attribute>

--- a/pdfarranger/pdfarranger.py
+++ b/pdfarranger/pdfarranger.py
@@ -335,6 +335,7 @@ class PdfArranger(Gtk.Application):
             ('delete', self.on_action_delete),
             ('duplicate', self.duplicate),
             ('crop', self.crop_page_dialog),
+            ('crop-white-borders', self.crop_white_borders),
             ('export-selection', self.choose_export_selection_pdf_name),
             ('reverse-order', self.reverse_order),
             ('save', self.on_action_save),
@@ -1563,6 +1564,78 @@ class PdfArranger(Gtk.Application):
             if oldcrop != crop:
                 self.set_unsaved(True)
         dialog.destroy()
+
+    def crop_white_borders(self, _action, _parameter, _unknown):
+        model = self.iconview.get_model()
+        selection = self.iconview.get_selected_items()
+
+        crop = []
+        for path in selection:
+            it = model.get_iter(path)
+            nfile, npage = model.get(it, 2, 3,)
+            pdfdoc = self.pdfqueue[nfile - 1]
+
+            page = pdfdoc.document.get_page(npage - 1)
+            w, h = page.get_size()
+            w = int(w)
+            h = int(h)
+            thumbnail = cairo.ImageSurface(cairo.FORMAT_ARGB32, w, h)
+            cr = cairo.Context(thumbnail)
+            page.render(cr)
+            data = thumbnail.get_data().cast("i", shape=[h,w]).tolist()
+
+            crop_this_page = [0.0, 0.0, 0.0, 0.0]
+
+            #Left
+            allwhite = True
+            for col in range(w-1):
+                for row in range(h-1):
+                    if data[row][col] != 0:
+                        allwhite = False
+                        crop_this_page[0] = (col)/w
+                        break
+                if not allwhite:
+                    break
+
+            #Right
+            allwhite = True
+            for col in range(w-1, 0, -1):
+                for row in range(h-1):
+                    if data[row][col] != 0:
+                        allwhite = False
+                        crop_this_page[1] = (w-col)/w
+                        break
+                if not allwhite:
+                    break
+
+            #Top
+            allwhite = True
+            for row in range(h-1):
+                for col in range(w-1):
+                    if data[row][col] != 0:
+                        allwhite = False
+                        crop_this_page[2] = (row)/h
+                        break
+                if not allwhite:
+                    break
+
+            #Bottom
+            allwhite = True
+            for row in range(h-1, 0, -1):
+                for col in range(w-1):
+                    if data[row][col] != 0:
+                        allwhite = False
+                        crop_this_page[3] = (h-row)/h
+                        break
+                if not allwhite:
+                    break
+
+            crop.append(crop_this_page)
+        
+        self.undomanager.commit("Crop white Borders")
+        oldcrop = self.crop(selection, crop)
+        if oldcrop != crop:
+            self.set_unsaved(True)
 
     def crop(self, selection, newcrop):
         oldcrop = [[0] * 4 for __ in range(len(selection))]


### PR DESCRIPTION
Some printers in CAD programs can only print to standard page sizes, if you want to create a PDF of custom size like extended A3, usual workflow is to print to A2 or A1 and then crop extra white border.

With this change this operation is completed with just one click.

Size of white borders is determined by rendering the page with Cairo and then examining pixels for color other then white. This seems like a brute force approach, but I couldn't find any other solution.

